### PR TITLE
AccessToken can be passed in via an env variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -341,3 +341,4 @@ healthchecksdb
 
 Properties/launchSettings.json
 /SmartThingsTerminal/Properties/launchSettings.json
+local.env

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,9 +10,14 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "/mnt/c/@SourceControl/Github/SmartThingsTerminal/SmartThingsTerminal/bin/Debug/netcoreapp3.1/STT.dll",
-            "args": ["-t {accessToken}"],
-            "cwd": "/mnt/c/@SourceControl/Github/SmartThingsTerminal/SmartThingsTerminal",
+            "program": "${workspaceFolder}/SmartThingsTerminal/bin/Debug/net5.0/STT.dll",
+            // Args takes precendence over environment variables
+            //"args": ["-t {accessToken}"],
+            //"env": {
+            //    "STT_ACCESSTOKEN": "{accessToken}"
+            // You can also place this env variable in a `local.env` file
+            //},
+            "cwd": "${workspaceFolder}/SmartThingsTerminal",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
             "console": "integratedTerminal",
             "stopAtEntry": false

--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ eg:
 $ ./STT -t {accesstoken} -s devices
 ```
 
+## Environment variables
+
+You can use an environment variable called `STT_ACCESSTOKEN` and `STT_SCREEN` in place of the command line arguments should you wish to not have to pass them on the command line. The Command Line takes precendence over any environment variables. In order of importance :- 
+- `local.env` file in the directory of the executable. VSCode is configured to copy this file to the target directory if you add it to the `SmartThingsTerminal` folder (same level as the csproj)
+- system environment variable. This is only used if command line or `.env` file are not present. An example is left commented out in the `launch.json` file.
+
 ## Full feature list
 
 * View Capability Summaries

--- a/SmartThingsTerminal/Program.cs
+++ b/SmartThingsTerminal/Program.cs
@@ -1,5 +1,4 @@
-﻿using CommandLine;
-using NStack;
+﻿using NStack;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -33,18 +32,13 @@ namespace SmartThingsTerminal
         private static bool _useSystemConsole = false;
         private static SmartThingsClient _stClient;
 
-        public class Options
-        {
-            [Option('t', "accesstoken", Required = true, HelpText = "OAuth Personal access token - generate from: https://account.smartthings.com/tokens")]
-            public string AccessToken { get; set; }
-
-            [Option('s', "screen", Required = false, HelpText = "Jump into a specific screen: [devices/installedapps/locations/rules/scenes/schedules/subscriptions]")]
-            public string ApiName { get; set; }
-        }
-
         static void Main(string[] args)
         {
-            CommandLine.Parser.Default.ParseArguments<Options>(args).WithParsed(Init);
+            Startup startup = new Startup();
+            if (startup.Configure(args))
+            {
+                Init(startup.Options);
+            }
         }
 
         private static void Init(Options opts)

--- a/SmartThingsTerminal/SmartThingsTerminal.csproj
+++ b/SmartThingsTerminal/SmartThingsTerminal.csproj
@@ -22,12 +22,17 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
+    <PackageReference Include="dotenv.net" Version="2.1.1" />
     <PackageReference Include="SmartThingsNet" Version="0.5.0" />
     <PackageReference Include="Terminal.Gui" Version="1.0.0-pre.6" />
   </ItemGroup>
 
   <ItemGroup>
     <Folder Include="Properties\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="*.env" CopyToOutputDirectory="Always" />
   </ItemGroup>
 
 </Project>

--- a/SmartThingsTerminal/Startup.cs
+++ b/SmartThingsTerminal/Startup.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using CommandLine;
+using dotenv.net;
+
+namespace SmartThingsTerminal
+{    
+    public class Options
+    {
+        [Option('t', "accesstoken", Required = true, HelpText = "OAuth Personal access token - generate from: https://account.smartthings.com/tokens")]
+        public string AccessToken { get; set; }
+
+        [Option('s', "screen", Required = false, HelpText = "Jump into a specific screen: [devices/installedapps/locations/rules/scenes/schedules/subscriptions]")]
+        public string ApiName { get; set; }
+    }
+
+    public class Startup
+    {
+        public Options Options
+        {
+            get;
+            set;
+        }
+        public bool Configure(string[] args)
+        {
+            // Precedence of reading config
+            // 1. Command Line Arguments
+            // 2. .env file in file tree
+            // 3. System Environment Variable
+            var parserResult = CommandLine.Parser.Default
+                .ParseArguments<Options>(args)
+                .WithNotParsed(ReadEnvironmentVariables)
+                .WithParsed(UseCommandLineArguments);
+
+            return Options != null;
+        }
+
+        private void ReadEnvironmentVariables(IEnumerable<Error> errors)
+        {
+            DotEnv.Config(false, "local.env");
+            var accessToken = System.Environment.GetEnvironmentVariable("STT_ACCESSTOKEN");
+            var screen = System.Environment.GetEnvironmentVariable("STT_SCREEN");
+
+            if (!string.IsNullOrEmpty(accessToken))
+            {
+                Options = new Options
+                {
+                    AccessToken = accessToken,
+                    ApiName = screen                    
+                };
+            }
+        }
+
+        private void UseCommandLineArguments(Options options)
+        {
+            this.Options = options;
+        }
+    }
+}


### PR DESCRIPTION
Made the following changes
- User can create a local.env file in the SmartThingsTerminal directory with a STT_ACCESSTOKEN value and this will be used. CommandLine still takes precedence. local.env is also ignored by Git
- Created new Startup class that will determine how to populate the Options. Order is CommandLine, Env File, System Environment variables
- Copy env file to build output directory if present

Happy to make amendments (and wont be offended if you dont take the work!). At the moment, you still get errors printed in the terminal if you are not using CommandLine, but you don't see them.