### PR TITLE
Catch null

### DIFF
--- a/SmartThingsTerminal/Scenarios/Devices.cs
+++ b/SmartThingsTerminal/Scenarios/Devices.cs
@@ -29,7 +29,7 @@ namespace SmartThingsTerminal.Scenarios
             Dictionary<string, string> displayItemList = null;
             try
             {
-                if (STClient.GetAllDevices().Items?.Count > 0)
+                if (STClient.GetAllDevices()?.Items?.Count > 0)
                 {
                     dataItemList = STClient.GetAllDevices().Items
                         .OrderBy(t => t.Label)


### PR DESCRIPTION
Avoid an exception if the underlying API returns a null